### PR TITLE
Fix bug: Chinese characters causes wrong width of column

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -67,8 +67,9 @@ function createTable() {
                     isNumberCol[j] = false;
                 }
             }
-            if (isNewCol || colLengths[j] < data.length) {
-               colLengths[j] = data.length;
+			//Chinese character displays double length than ASCII character
+            if (isNewCol || colLengths[j] < data.replace(/[^\x00-\xff]/g, '__').length) {
+               colLengths[j] = data.replace(/[^\x00-\xff]/g, '__').length;
             }
         }
     }
@@ -228,7 +229,8 @@ function createTable() {
                     align = "r";
                 }
             }
-            data = _pad(data, colLengths[j], " ", align);
+			//Chinese character displays double length than ASCII character
+            data = _pad(data, colLengths[j]-(data.replace(/[^\x00-\xff]/g, '__').length-data.length), " ", align);
             output += " " + data + " " + cV;
         }
         output += "\n";


### PR DESCRIPTION
Chinese characters are often displays wider than ASCII characters(double width in monospaced fonts). But Javascript `.length()` will compute it's length as 1. So I replaced them to `__` to compute the real length of columns.
