### PR TITLE
Update number column regex to allow floats

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -63,7 +63,7 @@ function createTable() {
             if (autoFormat) {
                 if (hasHeaders && i == 0 && !spreadSheetStyle) {
                     ; // a header is allowed to not be a number (exclude spreadsheet because the header hasn't been added yet
-                } else if (isNumberCol[j] && !data.match(/^(\s*-?\d+\s*|\s*)$/)) {
+                } else if (isNumberCol[j] && !data.match(/^(\s*-?\d+[.]*\d*\s*|\s*)$/)) {
                     isNumberCol[j] = false;
                 }
             }


### PR DESCRIPTION
The number column check only recognized integers. Updating the regex will allow decimal numbers to be recognized as numbers as well, to have appropriate alignment applied.
