### PR TITLE
Allow thousands-place separators

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -63,7 +63,7 @@ function createTable() {
             if (autoFormat) {
                 if (hasHeaders && i == 0 && !spreadSheetStyle) {
                     ; // a header is allowed to not be a number (exclude spreadsheet because the header hasn't been added yet
-                } else if (isNumberCol[j] && !data.match(/^(\s*-?\d+[.]*\d*\s*|\s*)$/)) {
+                } else if (isNumberCol[j] && !data.match(/^(\s*-?\d+(,\d{3})*[.]*\d*\s*|\s*)$/)) {
                     isNumberCol[j] = false;
                 }
             }


### PR DESCRIPTION
Updated regex so it allows commas to be thousands-place separators for number columns.
