### PR TITLE
Separator correction; auto-create tables

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -49,7 +49,7 @@ function createTable() {
         hasHeaders = true;
         // add the row numbers
         for (var i = 0; i < rows.length; i++) {
-            rows[i] = (i+1) + "\t" + rows[i];
+            rows[i] = (i+1) + separator + rows[i];
         }
     }    
 
@@ -93,7 +93,7 @@ function createTable() {
             if (90 < asciiVal) {
                 asciiVal = 90; // Z is the max column
             }
-            letterRow += "\t" + String.fromCharCode(asciiVal);
+            letterRow += separator + String.fromCharCode(asciiVal);
         }
         rows.splice(0, 0, letterRow); // add as first row
     }
@@ -182,7 +182,7 @@ function createTable() {
         cV = "\u2551";
         break;
     case "html":
-        outputAsNormalTable(rows, hasHeaders, colLengths);
+        outputAsNormalTable(rows, hasHeaders, colLengths, separator);
         return;
     default:
         break;
@@ -278,7 +278,7 @@ function createTable() {
     $('#outputTbl').hide();
 }
 
-function outputAsNormalTable(rows, hasHeaders, colLengths) {
+function outputAsNormalTable(rows, hasHeaders, colLengths, separator) {
     var output = "";
 
     var $outputTable = $('<table border="1" cellpadding="1" cellspacing="1">');

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script src="assets/js/script.js"></script>
     <script src="assets/js/bootstrap.min.js"></script>
 </head>
-<body class="dashboard">
+<body class="dashboard" onload="createTable()">
     <div id="wrap">
         <header class="jumbotron">
             <div class="container">
@@ -34,7 +34,7 @@
 
 <div>
 
-    <textarea class="form-control fixed-width " rows="5" id="input">Col1	Col2	Col3
+    <textarea class="form-control fixed-width " rows="5" id="input" onchange="createTable()" onkeyup="createTable()">Col1	Col2	Col3
 Value 1	Value 2	123
 Separate	cols    with a tab or 4 spaces
 This is a row with only one cell</textarea>
@@ -43,7 +43,7 @@ This is a row with only one cell</textarea>
         <div class="row">
             <label for="hdr-style" class="control-label" title="Select what should be used as a header">Header</label>
             <div>
-                <select class="form-control" id="hdr-style" title="Select what should be used as a header">
+                <select class="form-control" id="hdr-style" title="Select what should be used as a header" onchange="createTable()" onselect="createTable()">
                     <option value="none">None</option>
                     <option value="top" selected="true">First Row</option>
                     <option value="ssheet">Spreadsheet</option>
@@ -54,14 +54,14 @@ This is a row with only one cell</textarea>
         <div class="row">
             <label for="auto-format"  class="control-label" title="Center the headers in the output table">Center</label>
             <div class="">
-                <input class="form-control" id="auto-format" checked="true" type="checkbox" title="Center the headers in the output table">
+                <input class="form-control" id="auto-format" checked="true" type="checkbox" title="Center the headers in the output table" onchange="createTable()">
             </div>
         </div>
       
         <div class="row">
             <label for="style" class="control-label" title="Select the output format of the table">Style</label>
             <div>
-                <select id="style"  class="form-control" title="Select the output format of the table">
+                <select id="style"  class="form-control" title="Select the output format of the table" onchange="createTable()">
                     <option value="0">Ascii (mysql style)</option>
                     <option value="2">Ascii (alt style)</option>
                     <option value="3">Ascii (compact)</option>
@@ -77,7 +77,7 @@ This is a row with only one cell</textarea>
         <div class="row">
             <label for="separator" class="control-label" title="Leave blank for tab separator, add character for custom separator">Separator</label>
             <div>
-		<input class="form-control" id="separator" type="text" name="separator" maxlength="1" size="1" title="Leave blank for tab separator, add character for custom separator"  onfocus="this.value = ''" />
+		<input class="form-control" id="separator" type="text" name="separator" maxlength="1" size="1" title="Leave blank for tab separator, add character for custom separator"  onfocus="this.value = '';createTable()" onkeyup="createTable()" />
             </div>
         </div>
 


### PR DESCRIPTION
Separator was not being correctly applied to Spreadsheet style column and row headers, or to html table columns. User-defined separator character is now used for both of these cases.

Added function calls to index.html so the output table is auto-created when the user changes any parameters or input text, to speed up cycling through table styles.
