### PR TITLE
Rename "Wikimedia" to "Mediawiki" and other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Press **Create Table** to get something like:
 | This is a row with only one cell |         |                        |                |
 ```
 
-### Wikimedia markup
+### MediaWiki markup
 
 ```
 {| class="wikitable"
@@ -223,7 +223,7 @@ Leading characters can be added by selecting a comment style:
 | hash        | "# "                             | Perl/PowerShell/Python/R/Ruby   |
 | doubledash  | "-- "                            | ada/AppleScript/Haskell/Lua/SQL |
 | percent     | "% "                             | MATLAB                          |
-| singlespace | " " (1 space)                    | wikimedia                       |
+| singlespace | " " (1 space)                    | MediaWiki                       |
 | quadspace   | " &nbsp;&nbsp;&nbsp;" (4 spaces) | reddit                          |
 | singlequote | "' " (single quote)              | VBA                             |
 | rem         | "REM "                           | BASIC/DOS batch file            |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Press **Create Table** to get something like:
 '----------------------------------'---------'------------------------'----------------'
 ```
 
-
 ### ASCII table (bubbles style)
 ```
  o88888888888888888888888888888888888(_)888888888(_)888888888888888888888888(_)88888888888888888o 
@@ -122,7 +121,6 @@ Press **Create Table** to get something like:
  O8oooooooooooooooooooooooooooooooooo(_)ooooooooo(_)oooooooooooooooooooooooo(_)oooooooooooooooo8O 
 ```
 
-
 ### ASCII table (girder style)
 ```
 //==================================[]=========[]========================[]================\\
@@ -133,7 +131,6 @@ Press **Create Table** to get something like:
 || This is a row with only one cell ||         ||                        ||                ||
 \\==================================[]=========[]========================[]================//
 ```
-
 
 ### ASCII table (dots style)
 ```
@@ -206,6 +203,3 @@ Leading characters can be added by selecting a comment style:
 | exclamation | "! "                             | Fortran 90                      |
 | slantsplat  | "/* ... */ "                     | CSS                             |
 | xml         | "&lt;!-- ... --&gt;"             | XML                             |
-
-
-

--- a/README.md
+++ b/README.md
@@ -184,6 +184,34 @@ Press **Create Table** to get something like:
 
 ### Wikimedia markup
 
+```
+{| class="wikitable"
+
+! Col1
+! Col2
+! Col3
+! Numeric Column
+|-
+
+| Value 1
+| Value 2
+| 123
+| 10.0
+|-
+
+| Separate
+| cols
+| with a tab or 4 spaces
+| -2,027.1
+|-
+
+| This is a row with only one cell
+|
+|
+|
+|}
+```
+
 ### Or even a boring html &lt;table>
 
 Leading characters can be added by selecting a comment style:

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -140,7 +140,7 @@ function createTable() {
         prefix = "% ";
         break;
     case "singlespace":
-        // wikimedia
+        // mediawiki
         prefix = " ";
         break;
     case "quadspace":
@@ -314,8 +314,8 @@ function createTable() {
         hdV = "||"; hdH = "";
         spV = "| "; spH = "";
         break;
-    case "wikim":
-        // wikimedia
+    case "mediawiki":
+        // mediawiki
         hasLineSeparators = true;
         hasRightSide = false;
         autoFormat = false;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -34,25 +34,25 @@ function createTable() {
     var input = $('#input').val();
     var separator = $('#separator').val();
     var commenting = $('#commenting').val();
-    
+
     if (separator == "") {
         //Default separator is the tab
         separator = "\t";
-    } 
+    }
 
     var rows = input.split(/[\r\n]+/);
     if (rows[rows.length - 1] == "") {
         // extraneous last row, so delete it
         rows.pop();
     }
-    
+
     if (spreadSheetStyle) {
         hasHeaders = true;
         // add the row numbers
         for (var i = 0; i < rows.length; i++) {
             rows[i] = (i+1) + separator + rows[i];
         }
-    }    
+    }
 
     // calculate the max size of each column
     var colLengths = [];
@@ -84,8 +84,8 @@ function createTable() {
             }
         }
     }
-    
-    if (spreadSheetStyle) {    
+
+    if (spreadSheetStyle) {
         // now that we have the number of columns, add the letters
         var colCount = colLengths.length;
         var letterRow = " "; // initial column will have a space
@@ -108,7 +108,7 @@ function createTable() {
     var hasRightSide = true; // Defaults to including the right side line
     var topLineUsesBodySeparators = false; // Defaults to top line uses the same separators as the line between header and body
     var align; // Default alignment: left-aligned
-        
+
     // Add comment/remark indicators for use in code":
     commentbefore = "";
     commentafter  = "";
@@ -160,11 +160,11 @@ function createTable() {
         prefix = "C ";
         break;
     case "exclamation":
-        // Fortran 90 
+        // Fortran 90
         prefix = "! ";
         break;
     case "slantsplat":
-        // CSS 
+        // CSS
         prefix = "/* ";
         suffix = " */";
         break;
@@ -176,9 +176,9 @@ function createTable() {
     default:
         break;
     }
-    
+
     // Map of variable locations in the output:
-    // 
+    //
     // [cTL]   [hdH]  [cTM]   [hdH]  [cTR]
     // [hdV] Header 1 [hdV] Header 2 [hdV]
     // [cML]   [hdH]  [cMM]   [hdH]  [cMR]
@@ -186,7 +186,7 @@ function createTable() {
     // [cML]   [spH]  [cMM]   [spH]  [cMR]
     // [spV] Value 1a [spV] Value 2a [spV]
     // [cBL]   [spH]  [cBM]   [spH]  [cBR]
-    
+
     switch (style) {
     case "mysql":
         // ascii mysql style
@@ -194,8 +194,8 @@ function createTable() {
         cML = "+"; cMM = "+"; cMR = "+";
         cBL = "+"; cBM = "+"; cBR = "+";
 
-        hdV = "|"; hdH = "-"; 
-        spV = "|"; spH = "-"; 
+        hdV = "|"; hdH = "-";
+        spV = "|"; spH = "-";
         break;
     case "separated":
         // ascii 2
@@ -204,16 +204,16 @@ function createTable() {
         cML = "+"; cMM = "+"; cMR = "+";
         cBL = "+"; cBM = "+"; cBR = "+";
 
-        hdV = "|"; hdH = "="; 
-        spV = "|"; spH = "-"; 
+        hdV = "|"; hdH = "=";
+        spV = "|"; spH = "-";
         break;
     case "compact":
         // ascii - compact
         hasTopLine = false;
         hasBottomLine = false;
         cML = " "; cMM = " "; cMR = " ";
-        hdV = " "; hdH = "-"; 
-        spV = " "; spH = "-"; 
+        hdV = " "; hdH = "-";
+        spV = " "; spH = "-";
         break;
     case "rounded":
         // ascii rounded style
@@ -222,8 +222,8 @@ function createTable() {
         cML = ":"; cMM = "+"; cMR = ":";
         cBL = "'"; cBM = "'"; cBR = "'";
 
-        hdV = "|"; hdH = "-"; 
-        spV = "|"; spH = "-"; 
+        hdV = "|"; hdH = "-";
+        spV = "|"; spH = "-";
         break;
     case "girder":
         // ascii rounded style
@@ -231,8 +231,8 @@ function createTable() {
         cML = "|]"; cMM = "[]"; cMR = "[|";
         cBL = "\\\\"; cBM = "[]"; cBR = "//";
 
-        hdV = "||"; hdH = "="; 
-        spV = "||"; spH = "="; 
+        hdV = "||"; hdH = "=";
+        spV = "||"; spH = "=";
         break;
     case "bubbles":
         // ascii bubbled style
@@ -240,8 +240,8 @@ function createTable() {
         cML = "(88"; cMM = "(_)"; cMR = "88)";
         cBL = " O8"; cBM = "(_)"; cBR = "8O ";
 
-        hdV = "(_)"; hdH = "8"; 
-        spV = "(_)"; spH = "o"; 
+        hdV = "(_)"; hdH = "8";
+        spV = "(_)"; spH = "o";
         break;
     case "dots":
         // ascii dotted style
@@ -250,8 +250,8 @@ function createTable() {
         cBL = ":"; cBM = ":"; cBR = ":";
         sL  = ":"; sM  = "."; sR  = ":";
 
-        hdV = ":"; hdH = "."; 
-        spV = ":"; spH = "."; 
+        hdV = ":"; hdH = ".";
+        spV = ":"; spH = ".";
         break;
     case "gfm":
         // github markdown
@@ -261,8 +261,8 @@ function createTable() {
         cML = "|"; cMM = "|"; cMR = "|";
         cBL = "|"; cBM = "|"; cBR = "|";
 
-        hdV = "|"; hdH = "-"; 
-        spV = "|"; spH = "-"; 
+        hdV = "|"; hdH = "-";
+        spV = "|"; spH = "-";
         break;
     case "reddit":
         // reddit markdown
@@ -274,8 +274,8 @@ function createTable() {
         cML = " "; cMM = "|"; cMR = " ";
         cBL = " "; cBM = "|"; cBR = " ";
 
-        hdV = "|"; hdH = "-"; 
-        spV = "|"; spH = "-"; 
+        hdV = "|"; hdH = "-";
+        spV = "|"; spH = "-";
         break;
     case "rstGrid":
         // reStructuredText Grid markup
@@ -286,8 +286,8 @@ function createTable() {
         cML = "+"; cMM = "+"; cMR = "+";
         cBL = "+"; cBM = "+"; cBR = "+";
 
-        hdV = "|"; hdH = "="; 
-        spV = "|"; spH = "-"; 
+        hdV = "|"; hdH = "=";
+        spV = "|"; spH = "-";
         break;
     case "rstSimple":
         // reStructuredText Simple markup
@@ -297,8 +297,8 @@ function createTable() {
         cML = " "; cMM = " "; cMR = " ";
         cBL = " "; cBM = " "; cBR = " ";
 
-        hdV = " "; hdH = "="; 
-        spV = " "; spH = "="; 
+        hdV = " "; hdH = "=";
+        spV = " "; spH = "=";
         break;
     case "jira":
         // jira markdown
@@ -311,8 +311,8 @@ function createTable() {
         cML = ""; cMM = ""; cMR = "";
         cBL = ""; cBM = ""; cBR = "";
 
-        hdV = "||"; hdH = ""; 
-        spV = "| "; spH = ""; 
+        hdV = "||"; hdH = "";
+        spV = "| "; spH = "";
         break;
     case "wikim":
         // wikimedia
@@ -324,9 +324,9 @@ function createTable() {
         cML = "|-"; cMM = ""; cMR = "";
         cBL = ""; cBM = ""; cBR = "|}";
 
-        hdV = "\n!"; hdH = ""; 
-        spV = "\n|"; spH = ""; 
-        
+        hdV = "\n!"; hdH = "";
+        spV = "\n|"; spH = "";
+
         // also remove prefix/suffix:
         prefix = "";
         suffix = "";
@@ -337,8 +337,8 @@ function createTable() {
         cML = "\u2560"; cMM = "\u256C"; cMR = "\u2563";
         cBL = "\u255A"; cBM = "\u2569"; cBR = "\u255D";
 
-        hdV = "\u2551"; hdH = "\u2550"; 
-        spV = "\u2551"; spH = "\u2550"; 
+        hdV = "\u2551"; hdH = "\u2550";
+        spV = "\u2551"; spH = "\u2550";
         break;
     case "unicode_single_line":
         // unicode one line thick border
@@ -358,10 +358,10 @@ function createTable() {
 
     // output the text
     var output = "";
-    
+
     // echo comment wrapper if any
     output += commentbefore + "\n";
-    
+
     // output the top most row
     // Ex: +---+---+
     if (hasTopLine ) {
@@ -369,16 +369,16 @@ function createTable() {
             topLineHorizontal = spH;
         } else {
             topLineHorizontal = hdH;
-        } 
+        }
         output += getSeparatorRow(colLengths, cTL, cTM, cTR, topLineHorizontal, prefix, suffix)
     }
 
     for (var i = 0; i < rows.length; i++) {
         // Separator Rows
-        if (hasHeaders && hasHeaderSeparators && i == 1 ) { 
+        if (hasHeaders && hasHeaderSeparators && i == 1 ) {
             // output the header separator row
             output += getSeparatorRow(colLengths, cML, cMM, cMR, hdH, prefix, suffix)
-        } else if ( hasLineSeparators && i < rows.length ) { 
+        } else if ( hasLineSeparators && i < rows.length ) {
             // output line separators
             if( ( !hasHeaders && i >= 1 ) || ( hasHeaders && i > 1 ) ) {
                 output += getSeparatorRow(colLengths, cML, cMM, cMR, spH, prefix, suffix)
@@ -401,7 +401,7 @@ function createTable() {
                     align = "l";
                 }
             }
-            if (hasHeaders && i == 0 ) { 
+            if (hasHeaders && i == 0 ) {
                 verticalBar = hdV;
             } else {
                 verticalBar = spV;
@@ -421,7 +421,7 @@ function createTable() {
 
         }
     }
-    
+
     // output the bottom line
     // Ex: +---+---+
     if (hasBottomLine ) {
@@ -479,14 +479,14 @@ function parseTableClick() {
 
 function parseTable(table) {
     var separator = $('#separator').val();
-    
+
     if (separator == "") {
         //Default separator is the tab
         separator = "\t";
-    } 
-    
+    }
+
     var lines = table.split('\n');
-    
+
     // discard separator lines
     for (var i = 0; i < lines.length; i++) {
         var line = lines[i];
@@ -495,11 +495,11 @@ function parseTable(table) {
             i -= 1; // array size changed, decrement index to match
         }
     }
-    
+
     // http://stackoverflow.com/questions/6521245/finding-longest-string-in-array
     var copy_lines = lines.slice(0);
     var longest = copy_lines.sort(function (a, b) { return b.length - a.length; })[0];
-    
+
     // Identify column separators
     var colIndexes = [];
     for (var j = 0; j < longest.length; j++) {
@@ -507,7 +507,7 @@ function parseTable(table) {
             colIndexes.push(j);
         }
     }
-    
+
     if (colIndexes.length < 2) {
         alert("No results parsed. Whitespace is not yet parsable as a column separator.");
         return lines.join('\n');
@@ -515,9 +515,9 @@ function parseTable(table) {
         alert("No results parsed. Single lines are not yet parsable.");
         return lines.join('\n');
     }
-    
+
     alert("Parsed rows: " + lines.length + ", length: " + longest.length + ", column locations: " + colIndexes);
-    
+
     // Loop over all items and extract the data
     var result = "";
     for (var i = 0; i < lines.length; i++) {
@@ -532,11 +532,11 @@ function parseTable(table) {
             var data = line.slice(fromCol, toCol);
             data = _trim(data);
             result += data;
-            
+
             if (j < colIndexes.length - 2)
                 result += separator;
         }
-                
+
         if (i < lines.length - 1)
             result += '\n';
     }

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@ This is a row with only one cell</textarea>
 					<option value="dots">ASCII (dots)</option>
 					<option value="unicode">Unicode</option>
 					<option value="unicode_single_line">Unicode (single line)</option>
-					<option value="wikim">Wikimedia</option>
+					<option value="mediawiki">MediaWiki</option>
 					<option value="html">HTML</option>
 				</select>
 			</label>
@@ -101,7 +101,7 @@ This is a row with only one cell</textarea>
 					<option value="doubledash">"-- " ada/AppleScript/Haskell/Lua/SQL</option>
 					<option value="percent">"% " MATLAB </option>
 					<option value="docblock">" * " Docblock (PHP/Java/JS) </option>
-					<option value="singlespace">" " (1 space) wikimedia</option>
+					<option value="singlespace">" " (1 space) MediaWiki</option>
 					<option value="quadspace">" &nbsp;&nbsp;&nbsp;" (4 spaces) reddit</option>
 					<option value="singlequote">"' " (single quote) VBA</option>
 					<option value="rem">"REM " BASIC/DOS batch file</option>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ This is a row with only one cell</textarea>
     <div class="row text-center">
       <div class="well well-sm col-xs-10 col-xs-offset-1 col-sm-9 col-md-8 col-lg-offset-2 col-lg-6 col-lg-offset-3">
         <div class="col-xs-1"><h2 title="Settings" id="settings"><i class="fa fa-gear"></i></h2>
-          
+
         </div>
         <div class="col-xs-6">
           <div class="row">
@@ -115,11 +115,11 @@ This is a row with only one cell</textarea>
         </div>
         <div class="col-xs-5">
           <div class="row">
-            <label for="auto-format" class="control-label" title="Center the headers and right-align numbers in the output table">Auto-Format: 
+            <label for="auto-format" class="control-label" title="Center the headers and right-align numbers in the output table">Auto-Format:
             <input id="auto-format" checked="true" type="checkbox" title="Center the headers and right-align numbers in the output table" onchange="createTable()"></label>
           </div>
           <div class="row">
-            <label for="separator" class="control-label" title="Identify character for custom separator, default is the tab character">Custom Separator: 
+            <label for="separator" class="control-label" title="Identify character for custom separator, default is the tab character">Custom Separator:
             <input id="separator" type="text" name="separator" maxlength="1" size="1" onfocus="this.value = '';createTable()" onkeyup="createTable()"
             /></label>
           </div>


### PR DESCRIPTION
Wikimedia is the umbrella project that includes Wikipedia, Wiktionary, etc. The markup itself is actually called MediaWiki code, or just wikicode, and it is used by all wikis that are based in the same software, including many that are not Wikimedia projects.

This PR also adds a code example for mediawiki tables to the README, as well as small whitespace fixes.