### PR TITLE
Add "pipe" character to comments

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -173,6 +173,10 @@ function createTable() {
         prefix = "<!-- ";
         suffix = " -->";
         break;
+    case "pipe":
+        prefix = "|";
+        suffix = "|";
+        break;
     default:
         break;
     }

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@ This is a row with only one cell</textarea>
 					<option value="exclamation">"! " Fortran 90</option>
 					<option value="slantsplat">"/* ... */ " CSS </option>
 					<option value="xml">"&lt;!-- ... --&gt;" XML</option>
-					<option value="pipe">"|" Pipe</option>
+					<option value="pipe">"|" Reddit pipe</option>
 				</select>
 			</label>
           </div>

--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@ This is a row with only one cell</textarea>
 					<option value="exclamation">"! " Fortran 90</option>
 					<option value="slantsplat">"/* ... */ " CSS </option>
 					<option value="xml">"&lt;!-- ... --&gt;" XML</option>
+					<option value="pipe">"|" Pipe</option>
 				</select>
 			</label>
           </div>


### PR DESCRIPTION
I've noticed there's sometimes an issue with the Reddit Markdown output style, since the output isn't surrounded by pipes. This change addresses that by adding the pipe character ("|") as a comment option (easier that changing the output style). Closes ozh/ascii-tables#604938915