### PR TITLE
Fix bug in `isColumnSeparator()` parsing logic

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -566,7 +566,7 @@ function isColumnSeparator(lines, column) {
         }
         if (thisLine[column] == nextLine[column] && thisLine[column] != " ") {
             // Rows match, check next row down
-            return isColumnSeparator(lines.splice(0,1), column);
+            return isColumnSeparator(lines.splice(1), column);
         } else {
             // Rows are different, this is not a separator
             return false;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -560,11 +560,23 @@ function isColumnSeparator(lines, column) {
     } else {
         var thisLine = lines[0];
         var nextLine = lines[1];
+        
         if (column >= thisLine.length) {
             // Column is out of range, must not be a separator
             return false;
         }
-        if (thisLine[column] == nextLine[column] && thisLine[column] != " ") {
+        
+        var previousColumn = column-1;
+        var thisLineThisChar = thisLine[column];
+        var thisLinePreviousChar = (previousColumn > 0) ? thisLine[previousColumn] : " ";
+        var nextLineThisChar = nextLine[column];
+        var nextLinePreviousChar = (previousColumn > 0) ? nextLine[previousColumn] : " ";
+        
+        if (thisLineThisChar == nextLineThisChar 
+            && thisLineThisChar != " "
+            && thisLinePreviousChar == " "
+            && nextLinePreviousChar == " "
+           ) {
             // Rows match, check next row down
             return isColumnSeparator(lines.splice(1), column);
         } else {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -513,6 +513,9 @@ function parseTable(table) {
     for (var j = 0; j < longest.length; j++) {
         if (isColumnSeparator(lines.slice(), j)) {
             colIndexes.push(j);
+            // column separators are each padded by a space
+            // so skip over minimum distance between 2 columns
+            j += 2;
         }
     }
 
@@ -566,16 +569,15 @@ function isColumnSeparator(lines, column) {
             return false;
         }
         
-        var previousColumn = column-1;
+        var previousColumn = column - 1;
         var thisLineThisChar = thisLine[column];
         var thisLinePreviousChar = (previousColumn > 0) ? thisLine[previousColumn] : " ";
         var nextLineThisChar = nextLine[column];
         var nextLinePreviousChar = (previousColumn > 0) ? nextLine[previousColumn] : " ";
         
-        if (thisLineThisChar == nextLineThisChar 
-            && thisLineThisChar != " "
-            && thisLinePreviousChar == " "
-            && nextLinePreviousChar == " "
+        if (thisLineThisChar == nextLineThisChar
+            && !isSpace(thisLineThisChar)
+            && isSpace(thisLinePreviousChar, nextLinePreviousChar)
            ) {
             // Rows match, check next row down
             return isColumnSeparator(lines.splice(1), column);
@@ -588,6 +590,10 @@ function isColumnSeparator(lines, column) {
 
 function isSeparatorLine(line) {
     return line.trim().indexOf(" ") == -1; // must not have spaces
+}
+
+function isSpace(...chars) {
+    return chars.every(value => value == " ");
 }
 
 function _trim(str) {


### PR DESCRIPTION
The `isColumnSeparator()` logic is intended to check that each row contains the same (non-space) character in the same position.

Instead of checking the rows all the way down, however, it was only checking the first and second rows with a call to `slice(0,1)`.

Additionally, it was checking every column, when columns should each be padded by a space, making the minimum distance between columns two spaces.

Take the following table as an example:

```
AAA	BBB
BAB	ABA
ABA	BAB
```

If you enter that table as input, and then click the Parse button to parse the output, it considers any position where the characters in the same column position match across two rows to be a column separator.

So it interprets the middle column of each group as a separator, producing the following:

```
A	A	B	B
B	B	A	A
A	A	B	B
```

That stripped out the columns of:

```
A
A
B
```

and

```
B
B
A
```

because they have matching characters in the same column position in the first two rows.

### Changes

- Checks each row for a matching character in the same column position all the way to the last row (not just the first 2 rows), by recursively evaluating all remaining rows with `slice(1)` on each iteration.
- Checks that each column separator (aside from the first column at index 0) was preceded by a space.
- Because each column separator is padded by a space, two column separators should be a minimum of two columns apart. Adding this criterion ensures that empty columns with no value and columns containing a single character can be parsed correctly.

### Tests

- Input the following tables, then click the Parse button to parse the output back into the input.
- Observe that each table parses incorrectly at https://ozh.github.io/ascii-tables
- Verify that each table parses correctly at https://nekno.github.io/ascii-tables (where the code for this PR is live).

1. Single value columns
   ```
   A	B
   A	B
   ```
2. Empty columns
   ```
   A	B	C
   A		C
   ```
   ```
   A		C
   A		C
   ```
3. Columns with repeating values
   ```
   AAA	BBB
   BAB	ABA
   ABA	BAB
   ```