### PR TITLE
Measure column width by browser, Add left align for GFM

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -55,7 +55,7 @@ html, body {
 }
     
 .fixed-width {
-    font-family: courier new, monospace;
+    font-family: monospace;
 }
 
 #main {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -27,11 +27,14 @@ $(function() {
         height: 'auto',
         display: 'inline-block',
         font: $('#input').css('font'),
-        padding: 0
+        letterSpacing: 0,
+        padding: 0,
+        border: 0,
+        fontVariantLigatures: 'none'
     });
     
-    elMeasure.innerText = "x";
-    wSingle = elMeasure.clientWidth;
+    elMeasure.innerText = Array(11).join('x');
+    wSingle = elMeasure.clientWidth / 10;
 });
 
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -18,7 +18,8 @@ $(function() {
         }
     });
     
-    elMeasure = document.createElement('div');
+    elMeasure = document.createElement('pre');
+    document.body.appendChild(elMeasure);
     $(elMeasure).css({
         position: 'absolute',
         top: '-200px',
@@ -26,18 +27,19 @@ $(function() {
         height: 'auto',
         display: 'inline-block',
         font: $('#input').css('font'),
+        padding: 0
     });
     
-    document.body.appendChild(elMeasure);
-    elMeasure.innerText = ".";
-    wDot = elMeasure.clientWidth;
+    elMeasure.innerText = "x";
+    wSingle = elMeasure.clientWidth;
 });
 
 
-var elMeasure, wDot;
+var elMeasure, wSingle, _cache = {};
 function getUnicodeAwareLength(str) {
-    elMeasure.innerText = str;
-    return Math.round(elMeasure.clientWidth / wDot);
+    if (_cache[str] )return _cache[str]
+     elMeasure.innerText = str;
+    return _cache[str] = Math.round(elMeasure.clientWidth / wSingle);
 }
 
 // var regMultibyte = /[\uD800-\uDBFF][\uD800-\uDFFF]{,13}|[ㄱ-ㅎㅏ-ㅣ가-힣]|(?:[\x23-\x39\uFE0F\u20E3]{3})/g;
@@ -84,6 +86,7 @@ function createTable() {
     // calculate the max size of each column
     var colLengths = [];
     var isNumberCol = [];
+    _cache = {};
     for (var i = 0; i < rows.length; i++) {
         if (trimInput) {
             rows[i] = rows[i].trim();
@@ -96,7 +99,7 @@ function createTable() {
         }
         var cols = rows[i].split(separator);
         for (var j = 0; j < cols.length; j++) {
-            var data = cols[j];
+            var data = cols[j].trim();
             var isNewCol = colLengths[j] == undefined;
             if (isNewCol) {
                 isNumberCol[j] = true;
@@ -109,7 +112,7 @@ function createTable() {
                     isNumberCol[j] = false;
                 }
             }
-            if (isNewCol || colLengths[j] < data.length) {                
+            if (isNewCol || colLengths[j] < getUnicodeAwareLength(data)) {                
                 colLengths[j] = getUnicodeAwareLength(data);
             }
         }
@@ -426,7 +429,7 @@ function createTable() {
                 output += prefix;
             }
             var cols = rows[i].split(separator);
-            var data = cols[j] || "";
+            var data = (cols[j] || "").trim();
             if (autoFormat) {
                 if (hasHeaders && i == 0) {
                     align = "c";


### PR DESCRIPTION
# Issue
All CJK characters, like `안녕하세요` breaks width calculation since `'안녕하세요'.length === 5` unlike their apparent width. 

This is even more pronounced with various emojis. 

```ts
'🏴󠁧󠁢󠁷󠁬󠁳󠁿'.length === 14

'🏴󠁧󠁢󠁷󠁬󠁳󠁿'.split('').join() === 
  '\uD83C,\uDFF4,\uDB40,\uDC67,\uDB40,\uDC62,\uDB40,\uDC77,\uDB40,\uDC6C,\uDB40,\uDC73,\uDB40,\uDC7F'
```

I tried [various regex approaches](https://www.npmjs.com/package/emoji-regex) but there was no way I could cover them all. So I decided to just give up and let the browser renderer calculate the character count instead. Since this project was already running on jQuery ... I felt no need to go pure js this time.

This approach is still not perfect but it almost works. Especially compared to github's output.

| previous | improved | github editor |
|:--:|:--:|:--:|
| <img width="893" alt="image" src="https://user-images.githubusercontent.com/4316558/176018574-7ba714f9-4950-4520-a3ac-c28dddabe56e.png"> |<img width="586" alt="image" src="https://user-images.githubusercontent.com/4316558/176018411-d07b2eff-52a4-463c-bb7f-b37e4e172476.png">| <img width="588" alt="image" src="https://user-images.githubusercontent.com/4316558/176018631-3d798f21-3fdd-4b91-ae36-4f82fcba9d52.png">|

## Font
I've changed the font to monospace to reduce visual discrepancy but if you change the font to a true fixed width font you can achieve this beautiful result:

| D2Coding font|
|:--:|
|<img width="700" alt="image" src="https://user-images.githubusercontent.com/4316558/176018988-b240049e-758d-4de5-abed-f517fecf6357.png">|

However I decided to stick with good ol' `monospace`.

# GFM left align
I also added left align support for numeric columns and allow empty cells in numeric columns.


# Result

```

| +_+ | 안녕! |  ⛹🏾‍♂️  |  ☝🏿  | 🙌🏾🙌🏾 | . | .  |    .    | . | Number row |
|-----:|------:|------|------|------|--:|----|---------|--:|-------------:|
|    . |     1 | 😉😉 | 👍👍 | 2️⃣   | , | .  | .       | . |            1 |
|    . |     2 | .    | .    | .    | . | 🏴󠁧󠁢󠁷󠁬󠁳󠁿 | .       | . |            2 |
|    . |     3 | .    | .    | .    | . | .  | mañana | . |     123,456 |
|    . |     4 | .    | .    | .    | . | .  | mañana |   |              |


```

Far from perfect but hey , <img width="150" alt="I tried" src="https://user-images.githubusercontent.com/4316558/176020437-6eea5896-4e25-4bd3-888e-e80a6a67770c.png">

# Update
I tried canvas based measurement this time and it SLIGHTLY improved the result. See below, from the same input as above:


```gfm
| +_+ | 안녕! | ⛹🏾‍♂️   | ☝🏿   | 🙌🏾🙌🏾 | . | .  |   .    | . | Number row |
|----:|-----:|------|------|------|--:|----|--------|--:|-----------:|
|   . |    1 | 😉😉 | 👍👍 | 2️⃣   | , | .  | .      | . |          1 |
|   . |    2 | .    | .    | .    | . | 🏴󠁧󠁢󠁷󠁬󠁳󠁿 | .      | . |          2 |
|   . |    3 | .    | .    | .    | . | .  | mañana | . |    123,456 |
|   . |    4 | .    | .    | .    | . | .  | mañana |   |            |
```

Still struggles at emojis (they're measured as 2.14 character wide but 1.66 in the textarea ಠ_ಠ could be OSX/Chrome quirk...