### PR TITLE
Add MD Codeblock option

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -181,6 +181,11 @@ function createTable() {
         prefix = "|";
         suffix = "|";
         break;
+    case "codeblock":
+        // MD Codeblock
+        commentbefore = "```";
+        commentafter  = "```";
+        break;
     default:
         break;
     }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -182,7 +182,7 @@ function createTable() {
         suffix = "|";
         break;
     case "codeblock":
-        // MD Codeblock
+        // Markdown code block
         commentbefore = "```";
         commentafter  = "```";
         break;

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ This is a row with only one cell</textarea>
 					<option value="slantsplat">"/* ... */ " CSS </option>
 					<option value="xml">"&lt;!-- ... --&gt;" XML</option>
 					<option value="pipe">"|" Reddit pipe</option>
-          <option value="codeblock">"```" (triple backtick) Markdown codeblock (reddit, Github, Discord, Slack)</option>
+					<option value="codeblock">"```" (triple backtick) Markdown code block (reddit, Github, Discord, Slack)</option>
 				</select>
 			</label>
           </div>

--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@ This is a row with only one cell</textarea>
 					<option value="slantsplat">"/* ... */ " CSS </option>
 					<option value="xml">"&lt;!-- ... --&gt;" XML</option>
 					<option value="pipe">"|" Reddit pipe</option>
+          <option value="codeblock">"```" (triple backtick) Markdown codeblock (reddit, Github, Discord, Slack)</option>
 				</select>
 			</label>
           </div>


### PR DESCRIPTION
Adds the simple triple backtick option for use on places like discord or slack that require a codeblock to force monospacing.